### PR TITLE
finishing renaming changes that were left to do after appslist refactor

### DIFF
--- a/app/src/main/java/com/aptoide/uploader/UploaderApplication.java
+++ b/app/src/main/java/com/aptoide/uploader/UploaderApplication.java
@@ -7,8 +7,8 @@ import com.aptoide.uploader.account.network.AccountResponseMapper;
 import com.aptoide.uploader.account.network.RetrofitAccountService;
 import com.aptoide.uploader.account.persistence.SharedPreferencesAccountPersistence;
 import com.aptoide.uploader.apps.AccountStoreNameProvider;
-import com.aptoide.uploader.apps.AppsManager;
 import com.aptoide.uploader.apps.PackageManagerProvider;
+import com.aptoide.uploader.apps.StoreManager;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 import okhttp3.OkHttpClient;
@@ -19,7 +19,7 @@ import retrofit2.converter.moshi.MoshiConverterFactory;
 public class UploaderApplication extends Application {
 
   private AptoideAccountManager accountManager;
-  private AppsManager appsManager;
+  private StoreManager storeManager;
 
   public AptoideAccountManager getAccountManager() {
     if (accountManager == null) {
@@ -47,11 +47,11 @@ public class UploaderApplication extends Application {
     return accountManager;
   }
 
-  public AppsManager getAppsManager() {
-    if (appsManager == null) {
-      appsManager = new AppsManager(new PackageManagerProvider(getPackageManager()),
+  public StoreManager getAppsManager() {
+    if (storeManager == null) {
+      storeManager = new StoreManager(new PackageManagerProvider(getPackageManager()),
           new AccountStoreNameProvider(getAccountManager()));
     }
-    return appsManager;
+    return storeManager;
   }
 }

--- a/app/src/main/java/com/aptoide/uploader/account/view/AccountNavigator.java
+++ b/app/src/main/java/com/aptoide/uploader/account/view/AccountNavigator.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.support.v4.app.FragmentManager;
 import android.widget.Toast;
 import com.aptoide.uploader.R;
-import com.aptoide.uploader.apps.view.MyAppsFragment;
+import com.aptoide.uploader.apps.view.MyStoreFragment;
 
 public class AccountNavigator {
 
@@ -18,7 +18,7 @@ public class AccountNavigator {
 
   public void navigateToMyAppsView() {
     fragmentManager.beginTransaction()
-        .replace(R.id.activity_main_container, MyAppsFragment.newInstance())
+        .replace(R.id.activity_main_container, MyStoreFragment.newInstance())
         .commit();
   }
 

--- a/app/src/main/java/com/aptoide/uploader/apps/StoreManager.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/StoreManager.java
@@ -4,17 +4,17 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import java.util.List;
 
-public class AppsManager {
+public class StoreManager {
 
   private final PackageProvider packageProvider;
   private final StoreNameProvider storeNameProvider;
 
-  public AppsManager(PackageProvider packageProvider, StoreNameProvider storeNameProvider) {
+  public StoreManager(PackageProvider packageProvider, StoreNameProvider storeNameProvider) {
     this.packageProvider = packageProvider;
     this.storeNameProvider = storeNameProvider;
   }
 
-  public Single<Store> getApps() {
+  public Single<Store> getStore() {
     return Single.zip(getNonSystemApps(), storeNameProvider.getStoreName(),
         (apps, storeName) -> new Store(storeName, apps));
   }

--- a/app/src/main/java/com/aptoide/uploader/apps/view/MyStoreFragment.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/view/MyStoreFragment.java
@@ -53,6 +53,7 @@ public class MyStoreFragment extends FragmentView implements MyStoreView {
 
   @Override public void onDestroyView() {
     adapter = null;
+    storeNameText = null;
     recyclerView.setAdapter(null);
     recyclerView = null;
     super.onDestroyView();

--- a/app/src/main/java/com/aptoide/uploader/apps/view/MyStoreFragment.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/view/MyStoreFragment.java
@@ -19,14 +19,14 @@ import java.util.ArrayList;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
-public class MyAppsFragment extends FragmentView implements MyAppsView {
+public class MyStoreFragment extends FragmentView implements MyStoreView {
 
   private RecyclerView recyclerView;
   private MyAppsAdapter adapter;
   private TextView storeNameText;
 
-  public static MyAppsFragment newInstance() {
-    return new MyAppsFragment();
+  public static MyStoreFragment newInstance() {
+    return new MyStoreFragment();
   }
 
   @Nullable @Override
@@ -46,7 +46,7 @@ public class MyAppsFragment extends FragmentView implements MyAppsView {
         new DividerItemDecoration(getContext(), DividerItemDecoration.HORIZONTAL));
     adapter = new MyAppsAdapter(getLayoutInflater(), new ArrayList<>());
     recyclerView.setAdapter(adapter);
-    new MyAppsPresenter(this,
+    new MyStorePresenter(this,
         ((UploaderApplication) getContext().getApplicationContext()).getAppsManager(),
         new CompositeDisposable(), AndroidSchedulers.mainThread()).present();
   }

--- a/app/src/main/java/com/aptoide/uploader/apps/view/MyStorePresenter.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/view/MyStorePresenter.java
@@ -1,23 +1,23 @@
 package com.aptoide.uploader.apps.view;
 
-import com.aptoide.uploader.apps.AppsManager;
+import com.aptoide.uploader.apps.StoreManager;
 import com.aptoide.uploader.view.Presenter;
 import com.aptoide.uploader.view.View;
 import io.reactivex.Scheduler;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.exceptions.OnErrorNotImplementedException;
 
-public class MyAppsPresenter implements Presenter {
+public class MyStorePresenter implements Presenter {
 
-  private final MyAppsView view;
-  private final AppsManager appsManager;
+  private final MyStoreView view;
+  private final StoreManager storeManager;
   private final CompositeDisposable compositeDisposable;
   private final Scheduler viewScheduler;
 
-  public MyAppsPresenter(MyAppsView view, AppsManager appsManager,
+  public MyStorePresenter(MyStoreView view, StoreManager storeManager,
       CompositeDisposable compositeDisposable, Scheduler viewScheduler) {
     this.view = view;
-    this.appsManager = appsManager;
+    this.storeManager = storeManager;
     this.compositeDisposable = compositeDisposable;
     this.viewScheduler = viewScheduler;
   }
@@ -25,7 +25,7 @@ public class MyAppsPresenter implements Presenter {
   @Override public void present() {
     compositeDisposable.add(view.getLifecycleEvent()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
-        .flatMapSingle(__ -> appsManager.getApps())
+        .flatMapSingle(__ -> storeManager.getStore())
         .observeOn(viewScheduler)
         .doOnNext(store -> view.showStoreName(store.getName()))
         .doOnNext(store -> view.showApps(store.getApps()))

--- a/app/src/main/java/com/aptoide/uploader/apps/view/MyStoreView.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/view/MyStoreView.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
  * Created by pedroribeiro on 10/11/17.
  */
 
-public interface MyAppsView extends View {
+public interface MyStoreView extends View {
   void showApps(@NotNull List<App> appsList);
 
   void showStoreName(@NotNull String storeName);

--- a/app/src/test/kotlin/com/aptoide/uploader/apps/view/MyStorePresenterTest.kt
+++ b/app/src/test/kotlin/com/aptoide/uploader/apps/view/MyStorePresenterTest.kt
@@ -6,8 +6,8 @@ import com.aptoide.uploader.account.AptoideAccount
 import com.aptoide.uploader.account.AptoideAccountManager
 import com.aptoide.uploader.apps.AccountStoreNameProvider
 import com.aptoide.uploader.apps.App
-import com.aptoide.uploader.apps.AppsManager
 import com.aptoide.uploader.apps.PackageProvider
+import com.aptoide.uploader.apps.StoreManager
 import com.aptoide.uploader.view.View
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
@@ -24,16 +24,16 @@ import org.junit.platform.runner.JUnitPlatform
 import org.junit.runner.RunWith
 
 @RunWith(JUnitPlatform::class)
-class MyAppsPresenterTest : Spek({
+class MyStorePresenterTest : Spek({
     describe("a my apps presenter") {
         it("should display store name and installed apps when view is created") {
-            val view = mock<MyAppsView> {}
+            val view = mock<MyStoreView> {}
             val packageProvider = mock<PackageProvider> {}
             val accountService = mock<AccountService> {}
             val accountPersistence = mock<AccountPersistence> {}
             val storeNameProvider = AccountStoreNameProvider(AptoideAccountManager(accountService, accountPersistence))
-            val appsManager = AppsManager(packageProvider, storeNameProvider)
-            val installedAppsPresenter = MyAppsPresenter(view, appsManager, CompositeDisposable(), Schedulers.trampoline())
+            val appsManager = StoreManager(packageProvider, storeNameProvider)
+            val installedAppsPresenter = MyStorePresenter(view, appsManager, CompositeDisposable(), Schedulers.trampoline())
 
             val lifecycleEvent = PublishSubject.create<View.LifecycleEvent>()
             val facebook = App("https://myicon.com/facebook", "Facebook", false)


### PR DESCRIPTION
The apps list isn't an apps list only since we added the Store Name to the selection fragment.

That view now has a store name and a list of apps (which can be naturally referred as a Store - even tho the apps there are not from the store but are locally installed, the definition of 'store' is what naturally matches better).