### PR TITLE
migrate facebook v3 to v4. update vername to 2.11 (Minimum API 15 required)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,11 +50,11 @@ android {
 
   defaultConfig {
     applicationId "pt.caixamagica.aptoide.uploader"
-    minSdkVersion 9
+    minSdkVersion 15
     targetSdkVersion 23
     Integer value = project.VERSION_CODE_UPLOADER.toInteger();
     versionCode value
-    versionName "2.10"
+    versionName "2.11"
 
     vectorDrawables.useSupportLibrary = true
 
@@ -139,7 +139,7 @@ dependencies {
 
   compile 'com.github.manuelpeinado.multichoiceadapter:multichoiceadapter:3.1.0'
 
-  compile 'com.facebook.android:facebook-android-sdk:3.23.1'
+  compile 'com.facebook.android:facebook-android-sdk:4.16.0'
   compile 'com.google.android.gms:play-services-basement:9.8.0'
   compile 'com.google.android.gms:play-services-auth:9.8.0'
   compile 'com.google.android.gms:play-services-plus:9.8.0'

--- a/app/src/main/java/pt/caixamagica/aptoide/uploader/AptoideUploaderApplication.java
+++ b/app/src/main/java/pt/caixamagica/aptoide/uploader/AptoideUploaderApplication.java
@@ -10,7 +10,8 @@ import android.content.Context;
 import android.support.multidex.MultiDex;
 import android.text.TextUtils;
 import com.crashlytics.android.Crashlytics;
-import com.facebook.AppEventsLogger;
+import com.facebook.CallbackManager;
+import com.facebook.FacebookSdk;
 import com.octo.android.robospice.SpiceManager;
 import io.fabric.sdk.android.Fabric;
 import lombok.Getter;
@@ -33,6 +34,7 @@ public class AptoideUploaderApplication extends Application {
   @Getter @Setter private String username;
   private StoredCredentialsManager storedCredentialsManager;
   private AppsInStoreController appsInStoreController;
+  private CallbackManager callbackManager;
 
   public static Context getContext() {
     return context;
@@ -42,7 +44,7 @@ public class AptoideUploaderApplication extends Application {
     super.onCreate();
     Fabric.with(this, new Crashlytics());
     context = this;
-    AppEventsLogger.activateApp(this);
+    FacebookSdk.sdkInitialize(getApplicationContext());
 
     if (BuildConfig.DEBUG) {
       MultiDex.install(this);
@@ -53,6 +55,7 @@ public class AptoideUploaderApplication extends Application {
     if (hasStore()) {
       getAppsInStoreController().start();
     }
+    callbackManager = CallbackManager.Factory.create();
   }
 
   private boolean hasStore() {
@@ -74,5 +77,9 @@ public class AptoideUploaderApplication extends Application {
               new Md5AsyncUtils(this), getApplicationContext());
     }
     return appsInStoreController;
+  }
+
+  public CallbackManager getCallbackManager() {
+    return callbackManager;
   }
 }

--- a/app/src/main/java/pt/caixamagica/aptoide/uploader/FragmentAppView.java
+++ b/app/src/main/java/pt/caixamagica/aptoide/uploader/FragmentAppView.java
@@ -39,7 +39,7 @@ import android.widget.LinearLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
-import com.facebook.AppEventsLogger;
+import com.facebook.appevents.AppEventsLogger;
 import com.google.android.vending.licensing.ValidationException;
 import com.manuelpeinado.multichoiceadapter.MultiChoiceAdapter;
 import com.octo.android.robospice.SpiceManager;

--- a/app/src/main/java/pt/caixamagica/aptoide/uploader/activities/AppsListActivity.java
+++ b/app/src/main/java/pt/caixamagica/aptoide/uploader/activities/AppsListActivity.java
@@ -12,7 +12,7 @@ import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v7.app.ActionBarActivity;
 import android.support.v7.widget.Toolbar;
-import com.facebook.Session;
+import com.facebook.login.LoginManager;
 import pt.caixamagica.aptoide.uploader.AptoideUploaderApplication;
 import pt.caixamagica.aptoide.uploader.FragmentAppView;
 import pt.caixamagica.aptoide.uploader.LoginFragment;
@@ -80,20 +80,8 @@ public class AppsListActivity extends ActionBarActivity
   private void clearSessionInformation() {
     //Stop the activity
     AptoideUploaderApplication.setForcedLogout(true);
-    if (Session.getActiveSession() == null) {
-      if (Session.openActiveSessionFromCache(getApplicationContext()) != null) {
-        Session.getActiveSession()
-            .closeAndClearTokenInformation();
-        Session.getActiveSession()
-            .close();
-      }
-    } else if (Session.getActiveSession() != null) {
-      Session.getActiveSession()
-          .closeAndClearTokenInformation();
-      Session.getActiveSession()
-          .close();
-    }
-    Session.setActiveSession(null);
+    LoginManager.getInstance()
+        .logOut();
   }
 
   public void switchToLoginFragment() {

--- a/app/src/main/java/pt/caixamagica/aptoide/uploader/activities/LoginActivity.java
+++ b/app/src/main/java/pt/caixamagica/aptoide/uploader/activities/LoginActivity.java
@@ -22,7 +22,6 @@ import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Toast;
-import com.facebook.UiLifecycleHelper;
 import com.google.android.gms.auth.GoogleAuthException;
 import com.google.android.gms.auth.GoogleAuthUtil;
 import com.google.android.gms.auth.UserRecoverableAuthException;
@@ -68,7 +67,6 @@ public class LoginActivity extends AppCompatActivity
   private static final int MY_PERMISSIONS_REQUEST = 1;
   private static final int REQUEST_CODE_RESOLVE_ERR = 9000;
   final long DEFAULT_CACHE_TIME = DurationInMillis.ONE_SECOND * 5;
-  public UiLifecycleHelper uiLifecycleHelper;
 
   SpiceManager spiceManager = new SpiceManager(RetrofitSpiceServiceUploader.class);
 

--- a/app/src/main/java/pt/caixamagica/aptoide/uploader/analytics/UploaderAnalytics.java
+++ b/app/src/main/java/pt/caixamagica/aptoide/uploader/analytics/UploaderAnalytics.java
@@ -1,7 +1,7 @@
 package pt.caixamagica.aptoide.uploader.analytics;
 
 import android.os.Bundle;
-import com.facebook.AppEventsLogger;
+import com.facebook.appevents.AppEventsLogger;
 
 /**
  * Created by pedroribeiro on 20/06/17.

--- a/app/src/main/java/pt/caixamagica/aptoide/uploader/uploadService/UploadService.java
+++ b/app/src/main/java/pt/caixamagica/aptoide/uploader/uploadService/UploadService.java
@@ -21,7 +21,7 @@ import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
-import com.facebook.AppEventsLogger;
+import com.facebook.appevents.AppEventsLogger;
 import com.google.android.vending.licensing.AESObfuscator;
 import com.google.android.vending.licensing.ValidationException;
 import com.octo.android.robospice.SpiceManager;

--- a/app/src/main/res/layout/login_fragment.xml
+++ b/app/src/main/res/layout/login_fragment.xml
@@ -1,11 +1,8 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
 
     android:animateLayoutChanges="true"
-    tools:context=".MainActivity$PlaceholderFragment"
     >
 
   <ScrollView
@@ -74,15 +71,15 @@
           style="@style/Buttonuploader_button_theme"
           />
 
-      <com.facebook.widget.LoginButton
+      <com.facebook.login.widget.LoginButton
           android:id="@+id/fb_login_button"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_below="@+id/app_view_fragment"
           android:layout_margin="4dp"
-          app:confirm_logout="false"
-          app:fetch_user_info="true"
           />
+      <!--app:confirm_logout="false"-->
+      <!--app:fetch_user_info="true"-->
 
       <com.google.android.gms.common.SignInButton
           android:id="@+id/sign_in_button"


### PR DESCRIPTION
Facebook SDK update from v3 to v4.16.0

Updating facebook sdk involved redoing the whole Facebook Login login logic including changes to the facebook view widget and the way that callbacks are done. This was a good reference: https://developers.facebook.com/docs/android/upgrading-4x