### PR TITLE
[Up 17] Uploader form is not working

### DIFF
--- a/app/src/main/java/pt/caixamagica/aptoide/uploader/webservices/WebserviceOptions.java
+++ b/app/src/main/java/pt/caixamagica/aptoide/uploader/webservices/WebserviceOptions.java
@@ -11,5 +11,5 @@ package pt.caixamagica.aptoide.uploader.webservices;
 public class WebserviceOptions {
 
   public final static String WebServicesLink = "http://upload.webservices.aptoide.com/webservices/";
-  public final static String BASE_HOST_SECONDARY = "https://ws75-secondary.aptoide.com/api/7/";
+  public final static String BASE_HOST_SECONDARY = "https://ws75.aptoide.com/api/7/";
 }


### PR DESCRIPTION
This PR aims to fix a problem where the form for uploading an app was not filling up the categories, hence the upload could not be completed.

Fixed this behaviour by changing the WS from **ws75-secondary** to **ws75.aptoide.com**.

Ticket: [(https://aptoide.atlassian.net/browse/UP-17)](url)