### PR TITLE
[MOB-373] fix: wrong obb being uploaded when multiple files (of the same type)

### DIFF
--- a/app/src/main/java/com/aptoide/uploader/apps/PackageManagerInstalledAppsProvider.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/PackageManagerInstalledAppsProvider.java
@@ -9,6 +9,7 @@ import io.reactivex.Observable;
 import io.reactivex.Scheduler;
 import io.reactivex.Single;
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 
 public class PackageManagerInstalledAppsProvider implements InstalledAppsProvider {
@@ -46,6 +47,7 @@ public class PackageManagerInstalledAppsProvider implements InstalledAppsProvide
     if (obbDir.isDirectory()) {
       File[] files = obbDir.listFiles();
       if (files != null) {
+      Arrays.sort(files, (f1, f2) -> Long.compare(f2.lastModified(), f1.lastModified()));
         for (File file : files) {
           if (file.getName()
               .contains("main") && !file.getName()
@@ -67,6 +69,7 @@ public class PackageManagerInstalledAppsProvider implements InstalledAppsProvide
     if (obbDir.isDirectory()) {
       File[] files = obbDir.listFiles();
       if (files != null) {
+      Arrays.sort(files, (f1, f2) -> Long.compare(f2.lastModified(), f1.lastModified()));
         for (File file : files) {
           String arr[] = file.getName()
               .split("\\.", 2);


### PR DESCRIPTION
**What does this PR do?**

   Fixes the issue that exists when multiple obb's of the same type (main for example) exist in the Android/obb/<package> folder. This happens because listFiles doesn't guarantee order, so the first file that it lists will be the one being uploaded. This is an issue because if the user updates an app with obb's along multiple versions, depending on how the App Store handles file management, it might leave old version files behind (in Aptoide we do not clean obb's when installing a newer version, so it actually contributes to the error). What I've ended up doing was a simple sort by modified date DESC so it mitigates this problem, but it doesn't solve it.

**Where should the reviewer start?**

- [ ] PackageManagerInstalledAppsProvider.java

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [MOB-373](https://aptoide.atlassian.net/browse/MOB-373)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-373](https://aptoide.atlassian.net/browse/MOB-373)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional tests pass