### PR TITLE
[Bugfix][MOB-327] Fixed padding on app description Textview 

### DIFF
--- a/app/src/main/res/layout/submit_app_fragment.xml
+++ b/app/src/main/res/layout/submit_app_fragment.xml
@@ -207,6 +207,8 @@
             android:id="@+id/app_description"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp"
             android:background="@null"
             android:gravity="start"
             android:minHeight="200dp"


### PR DESCRIPTION
**What does this PR do?**

   Fixes the lack of padding in the textview from the submit app fragment that was making the text partially cut
   New bug (MOB-636) was created since we cant scroll inside of this textview.

**Where should the reviewer start?**

- submit_app_fragment.xml

**How should this be manually tested?**

  Upload an app that requires to go to the submit app screen and type on the app description

**What are the relevant tickets?**

   https://aptoide.atlassian.net/browse/MOB-327

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional tests pass