### PR TITLE
[fix/MOB-672] facebook login fail on fresh install

### DIFF
--- a/app/src/main/java/com/aptoide/uploader/security/AptoideAccessTokenProvider.java
+++ b/app/src/main/java/com/aptoide/uploader/security/AptoideAccessTokenProvider.java
@@ -50,7 +50,7 @@ public class AptoideAccessTokenProvider implements AuthenticationProvider {
 
   @Override public Single<String> getAccessTokenOAuth(String email, String token, String authMode) {
     String accessToken = authenticationPersistance.getAccessToken();
-    if (accessToken == null) {
+    if (accessToken == null || accessToken.equals("")) {
       final Map<String, String> args = new HashMap<>();
       args.put("authMode", authMode);
       args.put("oauthToken", token);


### PR DESCRIPTION
**What does this PR do?**

   Facebook login on fresh install was failing because previous to the login attempt the accessToken persisted is not null (empty string ""), which is the only validation we do. This would make it think the token was already retrieved and not retrieve a new one. We should look in the future into why is the auto-login (probable cause) saving an empty access token in the persistence layer. 

**Where should the reviewer start?**

- [ ] AptoideAccessTokenProvider.java

**How should this be manually tested?**

  clear data to simulate fresh install > login with facebook

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-672](https://aptoide.atlassian.net/browse/MOB-672)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional tests pass