### PR TITLE
[Bugfix/MOB-1040] Temporary removal of private stores

### DIFF
--- a/app/src/main/java/com/aptoide/uploader/account/view/CreateStoreFragment.java
+++ b/app/src/main/java/com/aptoide/uploader/account/view/CreateStoreFragment.java
@@ -32,10 +32,10 @@ public class CreateStoreFragment extends FragmentView
     implements CreateStoreView, OnBackPressedInterface {
 
   private EditText storeName;
-  private RadioButton publicStore;
-  private RadioButton privateStore;
-  private EditText storeUsername;
-  private EditText storePassword;
+  //private RadioButton publicStore;
+  //private RadioButton privateStore;
+  //private EditText storeUsername;
+  //private EditText storePassword;
   private Button createStoreButton;
   private CompositeDisposable compositeDisposable;
   private AptoideAccountManager accountManager;
@@ -60,12 +60,12 @@ public class CreateStoreFragment extends FragmentView
   @Override public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
 
-    storeName = view.findViewById(R.id.create_store_name);
-    publicStore = view.findViewById(R.id.public_store);
-    privateStore = view.findViewById(R.id.private_store);
-    storeUsername = view.findViewById(R.id.store_username);
-    storePassword = view.findViewById(R.id.store_password);
-    createStoreButton = view.findViewById(R.id.fragment_create_store_button);
+    storeName = view.findViewById(R.id.create_store_name_temp);
+    //publicStore = view.findViewById(R.id.public_store);
+    //privateStore = view.findViewById(R.id.private_store);
+    //storeUsername = view.findViewById(R.id.store_username);
+    //storePassword = view.findViewById(R.id.store_password);
+    createStoreButton = view.findViewById(R.id.fragment_create_store_button_temp);
     backPressedEvent = PublishSubject.create();
     logoutConfirmation = new RxAlertDialog.Builder(
         new ContextThemeWrapper(getContext(), R.style.ConfirmationDialog)).setMessage(
@@ -74,7 +74,7 @@ public class CreateStoreFragment extends FragmentView
         .setNegativeButton(R.string.no)
         .build();
 
-    RadioGroup storePrivacyRadioGroup = view.findViewById(R.id.create_store_privacy_radiogroup);
+  /*  RadioGroup storePrivacyRadioGroup = view.findViewById(R.id.create_store_privacy_radiogroup);
     compositeDisposable.add(RxRadioGroup.checkedChanges(storePrivacyRadioGroup)
         .skip(1)
         .map(id -> id == R.id.private_store)
@@ -85,7 +85,7 @@ public class CreateStoreFragment extends FragmentView
           } else {
             hidePrivateStoreFields();
           }
-        }));
+        }));*/
 
     new CreateStorePresenter(this, accountManager,
         new LoginNavigator(getFragmentManager(), getContext().getApplicationContext()),
@@ -95,10 +95,10 @@ public class CreateStoreFragment extends FragmentView
 
   @Override public void onDestroyView() {
     storeName = null;
-    publicStore = null;
-    privateStore = null;
-    storeUsername = null;
-    storePassword = null;
+    //publicStore = null;
+    //privateStore = null;
+    //storeUsername = null;
+    //storePassword = null;
     createStoreButton = null;
     backPressedEvent = null;
     super.onDestroyView();
@@ -108,22 +108,22 @@ public class CreateStoreFragment extends FragmentView
   public android.view.View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
       @Nullable Bundle savedInstanceState) {
     compositeDisposable = new CompositeDisposable();
-    return inflater.inflate(R.layout.fragment_create_store, container, false);
+    return inflater.inflate(R.layout.fragment_create_store_temp, container, false);
   }
 
-  private void hidePrivateStoreFields() {
+  /*private void hidePrivateStoreFields() {
     storeUsername.setVisibility(View.GONE);
     storePassword.setVisibility(View.GONE);
-  }
+  }*/
 
-  private void showPrivateStoreFields() {
+ /* private void showPrivateStoreFields() {
     storeUsername.setVisibility(View.VISIBLE);
     storePassword.setVisibility(View.VISIBLE);
-  }
+  }*/
 
-  private boolean isPrivateStore() {
+ /* private boolean isPrivateStore() {
     return privateStore.isChecked();
-  }
+  }*/
 
   @Override public Observable<CreateStoreViewModel> getStoreInfo() {
     return RxView.clicks(createStoreButton)
@@ -175,12 +175,12 @@ public class CreateStoreFragment extends FragmentView
   }
 
   @NonNull private CreateStoreViewModel getViewModel() {
-    if (isPrivateStore()) {
+    /*if (isPrivateStore()) {
       return new CreateStoreViewModel(storeName.getText()
           .toString(), storeUsername.getText()
           .toString(), storePassword.getText()
           .toString());
-    }
+    }*/
     return new CreateStoreViewModel(storeName.getText()
         .toString());
   }

--- a/app/src/main/res/layout/fragment_create_store_temp.xml
+++ b/app/src/main/res/layout/fragment_create_store_temp.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/gradient_drawable_maintenance"
+    >
+
+  <ImageView
+      android:id="@+id/uploader_icon"
+      android:layout_width="93dp"
+      android:layout_height="93dp"
+      android:layout_marginTop="93dp"
+      android:background="@drawable/ic_uploader_big"
+
+      app:layout_constraintLeft_toLeftOf="parent"
+      app:layout_constraintRight_toRightOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      />
+
+  <ImageView
+      android:id="@+id/cloud_background"
+      android:layout_width="140dp"
+      android:layout_height="140dp"
+      android:layout_marginStart="13dp"
+      android:layout_marginLeft="13dp"
+      android:layout_marginTop="60dp"
+      android:background="@drawable/background_clouds"
+      app:layout_constraintHorizontal_bias="1"
+      app:layout_constraintLeft_toRightOf="@id/uploader_icon"
+      app:layout_constraintRight_toRightOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      />
+
+  <TextView
+      android:id="@+id/create_store_info_temp"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginLeft="32dp"
+      android:layout_marginTop="43dp"
+      android:layout_marginRight="32dp"
+      android:textSize="14sp"
+      android:gravity="center"
+      android:text="@string/create_store_body"
+      app:layout_constraintLeft_toLeftOf="parent"
+      app:layout_constraintRight_toRightOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/uploader_icon"
+      />
+
+  <EditText
+      android:id="@+id/create_store_name_temp"
+      style="@style/EditTextWhite"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginLeft="32dp"
+      android:layout_marginTop="23dp"
+      android:layout_marginRight="32dp"
+      android:layout_marginBottom="28dp"
+      android:hint="@string/store"
+      android:padding="15dp"
+      android:singleLine="true"
+      android:textCursorDrawable="@null"
+      android:textSize="14sp"
+      app:layout_constraintLeft_toLeftOf="parent"
+      app:layout_constraintRight_toRightOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/create_store_info_temp"
+      />
+
+  <Button
+      android:id="@+id/fragment_create_store_button_temp"
+      style="@style/Aptoide.Button.White"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="32dp"
+      android:layout_marginLeft="32dp"
+      android:layout_marginTop="24dp"
+      android:layout_marginEnd="32dp"
+      android:layout_marginRight="32dp"
+      android:text="@string/create_repo"
+      app:layout_constraintLeft_toLeftOf="parent"
+      app:layout_constraintRight_toRightOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/create_store_name_temp"
+      tools:visibility="visible"
+      />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
**What does this PR do?**

 Prevents any user from creating a private store temporarily.
 - Created a new xml for the create store fragment with only the ability to input the store name
 - Commented any code related to private stores without removing it from the code.

**Where should the reviewer start?**

- CreateStoreFragment.java
- fragment_create_store_temp.xml

**How should this be manually tested?**

  Login with an account that doesn't have a store created, there should only be the option to type the name of the store an the button to create it

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/MOB-1040

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional tests pass