### PR TITLE
[APP-751] Remove last auto upload app

### DIFF
--- a/app/src/main/java/com/aptoide/uploader/apps/view/AutoUploadAppViewHolder.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/view/AutoUploadAppViewHolder.java
@@ -37,6 +37,7 @@ public class AutoUploadAppViewHolder extends RecyclerView.ViewHolder
         .into(appIcon);
     appName.setText(app.getName());
     checkBox.setChecked(selected);
+    checkBox.setClickable(false);
     if (!selected) {
       background.setBackgroundColor(itemView.getResources()
           .getColor(R.color.white));

--- a/app/src/main/java/com/aptoide/uploader/apps/view/AutoUploadAppsAdapter.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/view/AutoUploadAppsAdapter.java
@@ -61,11 +61,11 @@ public class AutoUploadAppsAdapter extends RecyclerView.Adapter<AutoUploadAppVie
       for (String packageName : selectedPackageNames) {
         if (app.getPackageName()
             .equals(packageName)) {
+          initialSelectedApps.add(i);
           selectApp(i);
         }
       }
     }
-    initialSelectedApps.addAll(selectedApps);
   }
 
   public void setInstalledAndSelectedApps(List<InstalledApp> appsList,

--- a/app/src/main/java/com/aptoide/uploader/apps/view/AutoUploadAppsAdapter.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/view/AutoUploadAppsAdapter.java
@@ -20,6 +20,7 @@ public class AutoUploadAppsAdapter extends RecyclerView.Adapter<AutoUploadAppVie
   private final List<Integer> selectedApps;
   private final AppSelectedListener selectedAppListener;
   private final PublishSubject<Boolean> selectedPublisher;
+  private final List<Integer> initialSelectedApps;
   private SortingOrder currentOrder;
 
   public AutoUploadAppsAdapter(@NonNull List<InstalledApp> list,
@@ -30,6 +31,7 @@ public class AutoUploadAppsAdapter extends RecyclerView.Adapter<AutoUploadAppVie
     this.selectedApps = new ArrayList<>();
     this.selectedAppListener = (view, position) -> selectApp(position);
     this.selectedPublisher = PublishSubject.create();
+    this.initialSelectedApps = new ArrayList<>();
   }
 
   @Override public AutoUploadAppViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
@@ -63,6 +65,7 @@ public class AutoUploadAppsAdapter extends RecyclerView.Adapter<AutoUploadAppVie
         }
       }
     }
+    initialSelectedApps.addAll(selectedApps);
   }
 
   public void setInstalledAndSelectedApps(List<InstalledApp> appsList,
@@ -111,12 +114,24 @@ public class AutoUploadAppsAdapter extends RecyclerView.Adapter<AutoUploadAppVie
   public void selectApp(int position) {
     if (selectedApps.contains(position)) {
       selectedApps.remove((Integer) position);
-      selectedPublisher.onNext(selectedApps.size() != 0);
     } else {
       selectedApps.add(position);
-      selectedPublisher.onNext(true);
     }
+    selectedPublisher.onNext(hasListChanged(selectedApps, initialSelectedApps));
     notifyItemChanged(position);
+  }
+
+  private boolean hasListChanged(List<Integer> selectedApps, List<Integer> initialSelectedApps) {
+    if (selectedApps.size() != initialSelectedApps.size()) {
+      return true;
+    } else {
+      for (Integer selectedApp : selectedApps) {
+        if (!initialSelectedApps.contains(selectedApp)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private void clearAppsSelection(boolean notify) {

--- a/app/src/main/java/com/aptoide/uploader/apps/view/AutoUploadPresenter.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/view/AutoUploadPresenter.java
@@ -97,20 +97,20 @@ public class AutoUploadPresenter implements Presenter {
   }
 
   private Completable handleSelectedApps() {
-    return loadSelectedApps().flatMap(__ -> view.submitSelectionClick())
-        .doOnNext(__ -> uploadPermissionProvider.requestExternalStoragePermission())
-        .flatMap(__ -> uploadPermissionProvider.permissionResultExternalStorage())
+    return loadSelectedApps().flatMapCompletable(__ -> view.submitSelectionClick()
+        .doOnNext(_1 -> uploadPermissionProvider.requestExternalStoragePermission())
+        .flatMap(_2 -> uploadPermissionProvider.permissionResultExternalStorage())
         .filter(granted -> granted)
-        .flatMapSingle(__ -> view.getSelectedApps())
+        .flatMapSingle(_3 -> view.getSelectedApps())
         .flatMap(selected -> view.getAutoUploadSelectedApps(selected))
         .flatMapCompletable(changedList -> installedAppsManager.updateAutoUploadApps(changedList)
             .doOnComplete(() -> autoUploadNavigator.navigateToSettingsFragment()))
+        .retry())
         .observeOn(viewScheduler)
         .doOnError(throwable -> {
           if (throwable instanceof SocketTimeoutException) {
             view.showError();
           }
-        })
-        .retry();
+        });
   }
 }

--- a/app/src/main/java/com/aptoide/uploader/apps/view/AutoUploadPresenter.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/view/AutoUploadPresenter.java
@@ -39,6 +39,18 @@ public class AutoUploadPresenter implements Presenter {
     showApps();
 
     refreshStoreAndApps();
+
+    disposeComposite();
+  }
+
+  private void disposeComposite() {
+    compositeDisposable.add(view.getLifecycleEvent()
+        .filter(event -> event.equals(View.LifecycleEvent.DESTROY))
+        .doOnNext(__ -> compositeDisposable.clear())
+        .subscribe(click -> {
+        }, throwable -> {
+          throw new OnErrorNotImplementedException(throwable);
+        }));
   }
 
   private void handleBackButtonClick() {

--- a/app/src/main/java/com/aptoide/uploader/apps/view/AutoUploadPresenter.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/view/AutoUploadPresenter.java
@@ -111,6 +111,7 @@ public class AutoUploadPresenter implements Presenter {
           if (throwable instanceof SocketTimeoutException) {
             view.showError();
           }
+          throwable.printStackTrace();
         });
   }
 }


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing the a bug where we would not be able to remove the last selection of the apps to be auto uploaded. Also fixed a bug where if the user pressed the checkbox, the row would not de-select.

**CONSIDERING that the other PR as some major flows fix, please review the APP-744 PR first.**

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AutoUploadAppFragment.java

**How should this be manually tested?**

Open the view, check that you can remove all selections and can save it.
**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-751](https://aptoide.atlassian.net/browse/APP-751)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass