### PR TITLE
  [AND-629] Fix edge-to-edge display issues on Auto-upload screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,15 +1,16 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'kotlin-android-extensions'
 
 android {
-  lintOptions {
+  namespace 'com.aptoide.uploader'
+
+  lint {
     checkReleaseBuilds false
     abortOnError false
   }
 
-  compileSdkVersion 28
+  compileSdk 35
 
   signingConfigs {
     release {
@@ -22,8 +23,8 @@ android {
 
   defaultConfig {
     applicationId "pt.caixamagica.aptoide.uploader"
-    minSdkVersion 16
-    targetSdkVersion 25
+    minSdk 21
+    targetSdk 35
     versionCode project.VERSION_CODE_UPLOADER.toInteger()
     versionName "3.1"
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -63,7 +64,7 @@ android {
     variant.outputs.each { output ->
       def project = "uploader"
       def SEP = "_"
-      def buildType = variant.variantData.variantConfiguration.buildType.name
+      def buildType = variant.buildType.name
       def versionName = variant.versionName
       def versionCode = variant.versionCode
 
@@ -78,44 +79,43 @@ android {
     test.java.srcDirs += 'src/test/kotlin'
     androidTest.java.srcDirs += 'src/androidTest/kotlin'
   }
+
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
   }
 
   kotlinOptions {
-    jvmTarget = "1.8"
+    jvmTarget = "17"
   }
 
-  dexOptions {
-    javaMaxHeapSize "4g"
-    dexInProcess = false
-    preDexLibraries = false
+  buildFeatures {
+    buildConfig = true
   }
 }
 
 dependencies {
 
   // Support Libraries
-  implementation 'androidx.appcompat:appcompat:1.1.0'
-  implementation 'com.google.android.material:material:1.0.0'
-  implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-  implementation "androidx.core:core-ktx:1.2.0"
-
+  implementation 'androidx.appcompat:appcompat:1.6.1'
+  implementation 'com.google.android.material:material:1.11.0'
+  implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+  implementation "androidx.core:core-ktx:1.12.0"
+  implementation 'androidx.activity:activity-ktx:1.8.2'
 
   // Reactive Programming
-  implementation "io.reactivex.rxjava2:rxjava:2.2.10"
-  implementation "com.jakewharton.rxbinding2:rxbinding-support-v4:2.0.0"
-  implementation 'com.jakewharton.rxrelay2:rxrelay:2.0.0'
-  implementation "androidx.room:room-rxjava2:2.2.3"
+  implementation "io.reactivex.rxjava2:rxjava:2.2.21"
+  implementation "com.jakewharton.rxbinding2:rxbinding-support-v4:2.2.0"
+  implementation 'com.jakewharton.rxrelay2:rxrelay:2.1.1'
+  implementation "androidx.room:room-rxjava2:2.6.1"
   api project(path: ':aptoide-authentication-rx')
 
   // Database
   // Room components
 
-  kapt "androidx.room:room-compiler:2.2.3"
-  implementation "androidx.room:room-runtime:2.2.3"
-  androidTestImplementation "androidx.room:room-testing:2.2.3"
+  kapt "androidx.room:room-compiler:2.6.1"
+  implementation "androidx.room:room-runtime:2.6.1"
+  androidTestImplementation "androidx.room:room-testing:2.6.1"
 
   // Kotlin
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
@@ -133,6 +133,7 @@ dependencies {
   implementation 'com.squareup.retrofit2:retrofit:2.5.0'
   implementation 'com.squareup.retrofit2:adapter-rxjava2:2.5.0'
   implementation 'com.squareup.retrofit2:converter-moshi:2.5.0'
+  implementation 'com.squareup.okhttp3:logging-interceptor:3.14.9'
 
   // Image Loading
   implementation 'com.github.bumptech.glide:glide:4.9.0'
@@ -145,13 +146,13 @@ dependencies {
   implementation "com.facebook.android:facebook-login:${FACEBOOK_SDK_VERSION}"
 
   //Google Sign-In
-  implementation 'com.google.android.gms:play-services-auth:16.0.0'
+  implementation 'com.google.android.gms:play-services-auth:20.7.0'
 
   //Play Services for Flurry
-  implementation 'com.google.android.gms:play-services-base:15.0.1'
+  implementation 'com.google.android.gms:play-services-base:18.3.0'
 
   //Chrome Custom tabs
-  implementation 'com.android.support:customtabs:28.0.0'
+  implementation 'androidx.browser:browser:1.7.0'
 
   //Rakam
   implementation "io.rakam:android-sdk:${RAKAM_VERSION}"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.aptoide.uploader">
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-  <uses-permission android:name="android.permission.GET_ACCOUNTS" />
   <uses-permission android:name="android.permission.INTERNET" />
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+  <!-- Required for Android 11+ to query all installed packages -->
+  <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+      tools:ignore="QueryAllPackagesPermission" />
 
   <application
     android:name=".UploaderApplication"
@@ -14,7 +20,9 @@
     android:icon="@mipmap/ic_launcher"
     android:label="@string/app_name"
     android:networkSecurityConfig="@xml/network_security_config"
-    android:theme="@style/AppTheme">
+    android:theme="@style/AppTheme"
+    android:appComponentFactory="androidx.core.app.CoreComponentFactory"
+    tools:replace="android:appComponentFactory">
 
     <meta-data
       android:name="com.facebook.sdk.ApplicationId"
@@ -23,7 +31,8 @@
     <activity
       android:name="com.facebook.FacebookActivity"
       android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
-      android:label="@string/app_name" />
+      android:label="@string/app_name"
+      android:exported="false" />
 
     <activity
       android:name="com.facebook.CustomTabActivity"
@@ -40,7 +49,8 @@
 
     <activity
       android:name=".MainActivity"
-      android:launchMode="singleTask">
+      android:launchMode="singleTask"
+      android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <action android:name="android.intent.action.MAIN" />
@@ -60,8 +70,13 @@
       </intent-filter>
     </activity>
 
-    <service android:name=".NotificationService" />
-    <receiver android:name=".apps.InstalledBroadcastReceiver">
+    <service 
+        android:name=".NotificationService"
+        android:foregroundServiceType="dataSync"
+        android:exported="false" />
+    <receiver 
+        android:name=".apps.InstalledBroadcastReceiver"
+        android:exported="true">
       <intent-filter android:priority="999">
         <action android:name="android.intent.action.PACKAGE_ADDED" />
         <action android:name="android.intent.action.PACKAGE_REMOVED" />
@@ -70,7 +85,9 @@
         <data android:scheme="package" />
       </intent-filter>
     </receiver>
-    <service android:name=".apps.InstalledIntentService" />
+    <service 
+        android:name=".apps.InstalledIntentService"
+        android:exported="false" />
   </application>
 
 </manifest>

--- a/app/src/main/java/com/aptoide/uploader/MainActivity.java
+++ b/app/src/main/java/com/aptoide/uploader/MainActivity.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.os.Bundle;
 import android.view.ContextThemeWrapper;
 import android.view.MenuItem;
+import androidx.activity.EdgeToEdge;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import com.aptoide.uploader.account.view.CreateStoreFragment;
@@ -23,6 +24,7 @@ public class MainActivity extends PermissionProviderActivity implements MainView
 
   @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    EdgeToEdge.enable(this);
 
     mainActivityNavigator = new MainActivityNavigator(getSupportFragmentManager());
 

--- a/app/src/main/java/com/aptoide/uploader/NotificationService.java
+++ b/app/src/main/java/com/aptoide/uploader/NotificationService.java
@@ -6,6 +6,7 @@ import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ServiceInfo;
 import android.os.Build;
 import android.os.IBinder;
 import android.util.Log;
@@ -88,7 +89,7 @@ public class NotificationService extends Service implements NotificationView {
             .setOnlyAlertOnce(true)
             .setProgress(0, 0, true);
     ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_DETACH);
-    startForeground(packageName.hashCode() + NOTIFICATION_ID_CHANGER, mBuilder.build());
+    startForegroundWithType(packageName.hashCode() + NOTIFICATION_ID_CHANGER, mBuilder.build());
   }
 
   @Override
@@ -100,7 +101,7 @@ public class NotificationService extends Service implements NotificationView {
     intent.putExtra("md5", md5);
     intent.putExtra("appName", applicationName);
     final PendingIntent contentIntent =
-        PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent.getActivity(this, 0, intent, getPendingIntentFlags());
 
     final Intent deleteIntent = new Intent(this, MainActivity.class);
     deleteIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
@@ -108,7 +109,7 @@ public class NotificationService extends Service implements NotificationView {
     deleteIntent.putExtra("md5", md5);
     deleteIntent.putExtra("appName", applicationName);
     final PendingIntent dismissIntent =
-        PendingIntent.getActivity(this, 0, deleteIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent.getActivity(this, 0, deleteIntent, getPendingIntentFlags());
 
     NotificationCompat.Builder mBuilder =
         new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID).setSmallIcon(
@@ -183,7 +184,7 @@ public class NotificationService extends Service implements NotificationView {
             .setOnlyAlertOnce(true)
             .setProgress(100, progress, false);
     ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_DETACH);
-    startForeground(packageName.hashCode() + NOTIFICATION_ID_CHANGER, mBuilder.build());
+    startForegroundWithType(packageName.hashCode() + NOTIFICATION_ID_CHANGER, mBuilder.build());
   }
 
   @Override
@@ -242,7 +243,7 @@ public class NotificationService extends Service implements NotificationView {
     intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
     intent.setAction("navigateToMyStoreFragment");
     final PendingIntent contentIntent =
-        PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent.getActivity(this, 0, intent, getPendingIntentFlags());
 
     return new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID).setSmallIcon(
         R.drawable.notification_icon)
@@ -272,5 +273,20 @@ public class NotificationService extends Service implements NotificationView {
 
   public UploadManager getUploadManager() {
     return this.uploadManager;
+  }
+
+  private void startForegroundWithType(int id, android.app.Notification notification) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      startForeground(id, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
+    } else {
+      startForeground(id, notification);
+    }
+  }
+
+  private int getPendingIntentFlags() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      return PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
+    }
+    return PendingIntent.FLAG_UPDATE_CURRENT;
   }
 }

--- a/app/src/main/java/com/aptoide/uploader/UploaderApplication.java
+++ b/app/src/main/java/com/aptoide/uploader/UploaderApplication.java
@@ -74,6 +74,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
 import org.json.JSONException;
 import org.json.JSONObject;
 import retrofit2.Retrofit;
@@ -114,7 +115,7 @@ public class UploaderApplication extends Application {
     startFlurryAgent();
     initializeRakam();
     getUploadManager().start();
-    checkFirstRun();
+    syncInstalledApps();
   }
 
   /**
@@ -143,17 +144,9 @@ public class UploaderApplication extends Application {
     getAutoLoginManager().getAutoLoginCredentials().setName("Debug User");
   }
 
-  public void checkFirstRun() {
-    boolean isFirstRun = this.getSharedPreferences("PREFERENCE", 0)
-        .getBoolean("isFirstRun", true);
-    if (isFirstRun) {
-      refreshInstalledApps();
-      refreshAutoUploadSelection();
-      this.getSharedPreferences("PREFERENCE", 0)
-          .edit()
-          .putBoolean("isFirstRun", false)
-          .apply();
-    }
+  public void syncInstalledApps() {
+    refreshInstalledApps();
+    refreshAutoUploadSelection();
   }
 
   private void refreshInstalledApps() {
@@ -239,10 +232,20 @@ public class UploaderApplication extends Application {
   }
 
   public OkHttpClient.Builder buildOkHttpClient() {
-    return new OkHttpClient.Builder().writeTimeout(60, TimeUnit.SECONDS)
+    OkHttpClient.Builder builder = new OkHttpClient.Builder()
+        .writeTimeout(60, TimeUnit.SECONDS)
         .readTimeout(60, TimeUnit.SECONDS)
         .connectTimeout(60, TimeUnit.SECONDS)
         .addInterceptor(getUserAgentInterceptor());
+
+    if (BuildConfig.DEBUG) {
+      HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor(
+          message -> Log.d("OkHttp", message));
+      loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+      builder.addInterceptor(loggingInterceptor);
+    }
+
+    return builder;
   }
 
   public Retrofit retrofitBuilder(String baseUrl, OkHttpClient.Builder okHttpClient) {
@@ -428,7 +431,6 @@ public class UploaderApplication extends Application {
 
   public GoogleSignInOptions getGSO() {
     return new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN).requestEmail()
-        .requestScopes(new Scope("https://www.googleapis.com/auth/contacts.readonly"))
         .requestScopes(new Scope(Scopes.PROFILE))
         .requestServerAuthCode(getString(R.string.google_id))
         .build();

--- a/app/src/main/java/com/aptoide/uploader/account/sendmagiclink/CheckYourEmailFragment.kt
+++ b/app/src/main/java/com/aptoide/uploader/account/sendmagiclink/CheckYourEmailFragment.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
 import com.aptoide.uploader.R
 import com.aptoide.uploader.UploaderApplication
 import com.aptoide.uploader.account.view.LoginNavigator
@@ -16,13 +17,17 @@ import com.aptoide.uploader.view.android.FragmentView
 import com.jakewharton.rxbinding2.view.RxView
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
-import kotlinx.android.synthetic.main.fragment_check_your_email.*
 
 class CheckYourEmailFragment : FragmentView(), CheckYourEmailView {
 
   lateinit var openEmailAppButton: Button
   lateinit var openEmailBody: TextView
   private var email: String? = null
+
+  private lateinit var toolbar: Toolbar
+  private lateinit var fragmentLoginLoadingTextView: TextView
+  private lateinit var checkYourEmailLayout: View
+  private lateinit var fragmentLoginProgressContainer: View
 
   companion object {
     private const val EMAIL = "email"
@@ -48,12 +53,20 @@ class CheckYourEmailFragment : FragmentView(), CheckYourEmailView {
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
+    bindViews(view)
     setupToolbar()
     setupViews(view)
     val app = (requireContext().applicationContext as UploaderApplication)
     CheckYourEmailPresenter(this, CheckYourEmailNavigator(activity), app.accountManager,
         AndroidSchedulers.mainThread(),
         LoginNavigator(fragmentManager, requireContext().applicationContext)).present()
+  }
+
+  private fun bindViews(view: View) {
+    toolbar = view.findViewById(R.id.toolbar)
+    fragmentLoginLoadingTextView = view.findViewById(R.id.fragment_login_loading_text_view)
+    checkYourEmailLayout = view.findViewById(R.id.check_your_email_layout)
+    fragmentLoginProgressContainer = view.findViewById(R.id.fragment_login_progress_container)
   }
 
   private fun setupViews(view: View) {
@@ -84,14 +97,14 @@ class CheckYourEmailFragment : FragmentView(), CheckYourEmailView {
   }
 
   override fun showLoadingWithoutUserName() {
-    fragment_login_loading_text_view.text = getString(R.string.logging_in)
-    check_your_email_layout.visibility = View.GONE
-    fragment_login_progress_container.visibility = View.VISIBLE
+    fragmentLoginLoadingTextView.text = getString(R.string.logging_in)
+    checkYourEmailLayout.visibility = View.GONE
+    fragmentLoginProgressContainer.visibility = View.VISIBLE
   }
 
   override fun hideLoading() {
-    check_your_email_layout.visibility = View.VISIBLE
-    fragment_login_progress_container.visibility = View.GONE
+    checkYourEmailLayout.visibility = View.VISIBLE
+    fragmentLoginProgressContainer.visibility = View.GONE
   }
 
 }

--- a/app/src/main/java/com/aptoide/uploader/account/sendmagiclink/SendMagicLinkView.kt
+++ b/app/src/main/java/com/aptoide/uploader/account/sendmagiclink/SendMagicLinkView.kt
@@ -4,25 +4,42 @@ import android.content.Context
 import android.text.SpannedString
 import android.util.AttributeSet
 import android.view.View
+import android.widget.Button
+import android.widget.EditText
 import android.widget.FrameLayout
+import android.widget.TextView
 import androidx.core.text.bold
 import androidx.core.text.buildSpannedString
 import com.aptoide.uploader.R
 import com.jakewharton.rxbinding2.view.RxView
 import com.jakewharton.rxbinding2.widget.RxTextView
 import io.reactivex.Observable
-import kotlinx.android.synthetic.main.send_magic_link_layout.view.*
 
 class SendMagicLinkView : FrameLayout {
   private var currentState: State? = null
+
+  private lateinit var loginBenefitsTextview: TextView
+  private lateinit var sendMagicLinkButton: Button
+  private lateinit var emailEditText: EditText
+  private lateinit var tip: TextView
+  private lateinit var tipError: TextView
 
   constructor(context: Context) : this(context, null)
   constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
   constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs,
       defStyleAttr) {
     inflate(context, R.layout.send_magic_link_layout, this)
+    bindViews()
     setupViews()
     isSaveEnabled = true
+  }
+
+  private fun bindViews() {
+    loginBenefitsTextview = findViewById(R.id.login_benefits_textview)
+    sendMagicLinkButton = findViewById(R.id.send_magic_link_button)
+    emailEditText = findViewById(R.id.email)
+    tip = findViewById(R.id.tip)
+    tipError = findViewById(R.id.tip_error)
   }
 
   private fun setupViews() {
@@ -33,7 +50,7 @@ class SendMagicLinkView : FrameLayout {
       append(" - ")
       append(context.getText(R.string.login_safe_body_2))
     }
-    login_benefits_textview.text = string
+    loginBenefitsTextview.text = string
   }
 
   fun setState(state: State) {
@@ -47,35 +64,35 @@ class SendMagicLinkView : FrameLayout {
   }
 
   fun getMagicLinkSubmit(): Observable<String> {
-    return RxView.clicks(send_magic_link_button)
-        .map { email.text.toString() }
+    return RxView.clicks(sendMagicLinkButton)
+        .map { emailEditText.text.toString() }
   }
 
   fun getEmailChangeEvent(): Observable<String> {
-    return RxTextView.textChangeEvents(email)
-        .map { email.text.toString() }
+    return RxTextView.textChangeEvents(emailEditText)
+        .map { emailEditText.text.toString() }
   }
 
   fun getSecureLoginTextClick(): Observable<Any> {
-    return RxView.clicks(login_benefits_textview)
+    return RxView.clicks(loginBenefitsTextview)
   }
 
   private fun setInitialState() {
     tip.visibility = View.VISIBLE
-    tip_error.visibility = View.GONE
+    tipError.visibility = View.GONE
 
-    email.setTextColor(resources.getColor(R.color.white))
-    email.setBackgroundResource(R.drawable.button_border_grey)
+    emailEditText.setTextColor(resources.getColor(R.color.white))
+    emailEditText.setBackgroundResource(R.drawable.button_border_grey)
   }
 
   private fun setErrorState(message: String, textFieldError: Boolean) {
     tip.visibility = View.GONE
-    tip_error.visibility = View.VISIBLE
-    tip_error.text = message
+    tipError.visibility = View.VISIBLE
+    tipError.text = message
 
     if (textFieldError) {
-      email.setTextColor(resources.getColor(R.color.darker_red))
-      email.setBackgroundResource(R.drawable.button_border_red)
+      emailEditText.setTextColor(resources.getColor(R.color.darker_red))
+      emailEditText.setBackgroundResource(R.drawable.button_border_red)
     }
   }
 

--- a/app/src/main/java/com/aptoide/uploader/apps/InstalledIntentService.kt
+++ b/app/src/main/java/com/aptoide/uploader/apps/InstalledIntentService.kt
@@ -28,8 +28,7 @@ open class InstalledIntentService : IntentService("InstalledIntentService") {
   override fun onHandleIntent(intent: Intent?) {
     if (intent != null) {
       val action = intent.action
-      val packageName = intent.data
-          .encodedSchemeSpecificPart
+      val packageName = intent.data?.encodedSchemeSpecificPart ?: return
       if (!TextUtils.equals(action, Intent.ACTION_PACKAGE_REPLACED) && intent.getBooleanExtra(
               Intent.EXTRA_REPLACING, false)) {
         return

--- a/app/src/main/java/com/aptoide/uploader/apps/PackageManagerInstalledAppsProvider.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/PackageManagerInstalledAppsProvider.java
@@ -41,7 +41,21 @@ public class PackageManagerInstalledAppsProvider implements InstalledAppsProvide
   }
 
   @Override public Single<List<InstalledApp>> getNonSystemInstalledApps() {
-    return getInstalledApps().flatMapObservable(apps -> Observable.fromIterable(apps))
+    return getInstalledApps()
+        .doOnSuccess(apps -> {
+          int systemCount = 0;
+          int nonSystemCount = 0;
+          for (InstalledApp app : apps) {
+            if (app.isSystem()) {
+              systemCount++;
+            } else {
+              nonSystemCount++;
+              Log.d("APP-85", "Non-system app: " + app.getPackageName() + " - " + app.getName());
+            }
+          }
+          Log.d("APP-85", "Total apps: " + apps.size() + ", System: " + systemCount + ", Non-system: " + nonSystemCount);
+        })
+        .flatMapObservable(apps -> Observable.fromIterable(apps))
         .filter(app -> !app.isSystem())
         .toList();
   }

--- a/app/src/main/java/com/aptoide/uploader/apps/ServiceBackgroundService.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/ServiceBackgroundService.java
@@ -3,6 +3,7 @@ package com.aptoide.uploader.apps;
 import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
+import androidx.core.content.ContextCompat;
 import com.aptoide.uploader.NotificationService;
 import com.aptoide.uploader.upload.BackgroundService;
 
@@ -20,7 +21,7 @@ public class ServiceBackgroundService implements BackgroundService {
   }
 
   @Override public void enable() {
-    context.startService(new Intent(context, serviceClass));
+    ContextCompat.startForegroundService(context, new Intent(context, serviceClass));
   }
 
   @Override public void disable() {

--- a/app/src/main/java/com/aptoide/uploader/apps/permission/UploadPermissionProvider.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/permission/UploadPermissionProvider.java
@@ -1,7 +1,9 @@
 package com.aptoide.uploader.apps.permission;
 
 import android.Manifest;
+import android.os.Build;
 import io.reactivex.Observable;
+import io.reactivex.subjects.PublishSubject;
 
 /**
  * Created by filipe on 02-01-2018.
@@ -11,19 +13,54 @@ public class UploadPermissionProvider {
 
   private final PermissionProvider permissionProvider;
   private final int EXTERNAL_STORAGE_PERMISSION_REQUEST_CODE = 1;
+  private final int NOTIFICATION_PERMISSION_REQUEST_CODE = 2;
+  private final PublishSubject<Boolean> storagePermissionSubject = PublishSubject.create();
+  private final PublishSubject<Boolean> notificationPermissionSubject = PublishSubject.create();
 
   public UploadPermissionProvider(PermissionProvider permissionProvider) {
     this.permissionProvider = permissionProvider;
   }
 
   public void requestExternalStoragePermission() {
+    // On Android 13+ (API 33+), READ_EXTERNAL_STORAGE is deprecated and not needed
+    // for reading app APKs. Emit granted immediately.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      storagePermissionSubject.onNext(true);
+      return;
+    }
     permissionProvider.providePermissions(new String[] {
         Manifest.permission.READ_EXTERNAL_STORAGE
     }, EXTERNAL_STORAGE_PERMISSION_REQUEST_CODE);
   }
 
   public Observable<Boolean> permissionResultExternalStorage() {
+    // On Android 13+ (API 33+), permission is not needed - listen to the subject
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      return storagePermissionSubject.hide();
+    }
     return permissionProvider.permissionResults(EXTERNAL_STORAGE_PERMISSION_REQUEST_CODE)
+        .map(permissions -> permissions.get(0)
+            .isGranted());
+  }
+
+  public void requestNotificationPermission() {
+    // Notification permission is only required on Android 13+ (API 33+)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      permissionProvider.providePermissions(new String[] {
+          Manifest.permission.POST_NOTIFICATIONS
+      }, NOTIFICATION_PERMISSION_REQUEST_CODE);
+    } else {
+      // On older versions, notification permission is granted by default
+      notificationPermissionSubject.onNext(true);
+    }
+  }
+
+  public Observable<Boolean> permissionResultNotification() {
+    // On Android < 13, notification permission is granted by default
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+      return notificationPermissionSubject.hide();
+    }
+    return permissionProvider.permissionResults(NOTIFICATION_PERMISSION_REQUEST_CODE)
         .map(permissions -> permissions.get(0)
             .isGranted());
   }

--- a/app/src/main/java/com/aptoide/uploader/apps/view/AppDetailsFragment.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/view/AppDetailsFragment.java
@@ -8,9 +8,14 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
+import android.widget.ScrollView;
 import android.widget.TextView;
 import android.widget.Toast;
 import androidx.annotation.Nullable;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import com.aptoide.uploader.R;
 import com.aptoide.uploader.UploaderApplication;
 import com.aptoide.uploader.apps.AppDetailsDataProvider;
@@ -47,6 +52,8 @@ public class AppDetailsFragment extends FragmentView implements AppDetailsView {
   private TextView installDate;
   private TextView updateDate;
   private ProgressBar loadingSpinner;
+  private Toolbar toolbar;
+  private ScrollView scrollView;
 
   public AppDetailsFragment() {
   }
@@ -72,6 +79,8 @@ public class AppDetailsFragment extends FragmentView implements AppDetailsView {
   @Override public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
 
+    toolbar = view.findViewById(R.id.fragment_app_details_toolbar);
+    scrollView = view.findViewById(R.id.fragment_app_details_scroll);
     backButton = view.findViewById(R.id.fragment_app_details_back);
     appIcon = view.findViewById(R.id.fragment_app_details_icon);
     appName = view.findViewById(R.id.fragment_app_details_app_name);
@@ -88,6 +97,8 @@ public class AppDetailsFragment extends FragmentView implements AppDetailsView {
     installDate = view.findViewById(R.id.fragment_app_details_install_date);
     updateDate = view.findViewById(R.id.fragment_app_details_update_date);
     loadingSpinner = view.findViewById(R.id.fragment_app_details_loading);
+
+    setupEdgeToEdgeInsets(view);
 
     String pkgName = getArguments() != null ? getArguments().getString(ARG_PACKAGE_NAME) : null;
 
@@ -119,6 +130,8 @@ public class AppDetailsFragment extends FragmentView implements AppDetailsView {
     installDate = null;
     updateDate = null;
     loadingSpinner = null;
+    toolbar = null;
+    scrollView = null;
     super.onDestroyView();
   }
 
@@ -207,5 +220,22 @@ public class AppDetailsFragment extends FragmentView implements AppDetailsView {
 
   @Override public Observable<Object> backButtonClick() {
     return RxView.clicks(backButton);
+  }
+
+  private void setupEdgeToEdgeInsets(View view) {
+    // Handle top insets for toolbar (status bar)
+    ViewCompat.setOnApplyWindowInsetsListener(toolbar, (v, insets) -> {
+      Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+      v.setPadding(v.getPaddingLeft(), systemBars.top, v.getPaddingRight(), v.getPaddingBottom());
+      return insets;
+    });
+
+    // Handle bottom insets for scroll view content
+    ViewCompat.setOnApplyWindowInsetsListener(scrollView, (v, insets) -> {
+      Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+      v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(), systemBars.bottom);
+      return insets;
+    });
+    scrollView.setClipToPadding(false);
   }
 }

--- a/app/src/main/java/com/aptoide/uploader/apps/view/AutoUploadFragment.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/view/AutoUploadFragment.java
@@ -11,6 +11,9 @@ import android.widget.ImageView;
 import android.widget.Toast;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -68,6 +71,7 @@ public class AutoUploadFragment extends FragmentView implements AutoUploadView {
     refreshLayout.setOnRefreshListener(() -> refreshEvent.onNext(true));
     setUpSubmitButtonAnimation();
     setUpSelectionListener();
+    setupEdgeToEdgeInsets(view);
     toolbar.setNavigationOnClickListener(click -> adapter.clearAppsSelection());
 
     new AutoUploadPresenter(this, new CompositeDisposable(), AndroidSchedulers.mainThread(),
@@ -185,5 +189,31 @@ public class AutoUploadFragment extends FragmentView implements AutoUploadView {
     slideBottomUp = AnimationUtils.loadAnimation(getContext(), R.anim.slide_bottom_up);
     slideBottomUp.setAnimationListener(showBottom);
     slideBottomDown.setAnimationListener(hideBottom);
+  }
+
+  private void setupEdgeToEdgeInsets(View view) {
+    // Toolbar padding for status bar
+    ViewCompat.setOnApplyWindowInsetsListener(toolbar, (v, insets) -> {
+      Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+      v.setPadding(v.getPaddingLeft(), systemBars.top, v.getPaddingRight(), v.getPaddingBottom());
+      return insets;
+    });
+
+    // RecyclerView bottom padding for navigation bar
+    ViewCompat.setOnApplyWindowInsetsListener(recyclerView, (v, insets) -> {
+      Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+      v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(), systemBars.bottom);
+      return insets;
+    });
+    recyclerView.setClipToPadding(false);
+
+    // Submit button bottom margin for navigation bar
+    ViewCompat.setOnApplyWindowInsetsListener(submitButton, (v, insets) -> {
+      Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+      ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+      params.bottomMargin = systemBars.bottom;
+      v.setLayoutParams(params);
+      return insets;
+    });
   }
 }

--- a/app/src/main/java/com/aptoide/uploader/apps/view/MyStoreFragment.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/view/MyStoreFragment.java
@@ -21,6 +21,9 @@ import android.widget.Toast;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import cm.aptoide.aptoideviews.recyclerview.GridRecyclerView;
@@ -93,6 +96,7 @@ public class MyStoreFragment extends FragmentView implements MyStoreView {
     mainScreen = view.findViewById(R.id.grid_view_and_hint);
     storeBanner = view.findViewById(R.id.store_info);
     submitButton = view.findViewById(R.id.submit_button);
+    setupEdgeToEdgeInsets(view);
     prepareSpinner(R.array.sort_spinner_array);
     setUpSubmitButtonAnimation();
     recyclerView.setLayoutManager(new GridLayoutManager(getContext(), 3));
@@ -230,6 +234,11 @@ public class MyStoreFragment extends FragmentView implements MyStoreView {
 
   @Override public void showNoConnectivityError() {
     Toast.makeText(getContext(), R.string.no_connectivity_error, Toast.LENGTH_LONG)
+        .show();
+  }
+
+  @Override public void showNotificationPermissionRequired() {
+    Toast.makeText(getContext(), R.string.notification_permission_required, Toast.LENGTH_LONG)
         .show();
   }
 
@@ -420,5 +429,66 @@ public class MyStoreFragment extends FragmentView implements MyStoreView {
       toolbar.setNavigationIcon(null);
       settingsItem.setVisibility(View.VISIBLE);
     }
+  }
+
+  private void setupEdgeToEdgeInsets(View view) {
+    // Handle top insets for toolbar (status bar) - toolbar extends behind status bar
+    ViewCompat.setOnApplyWindowInsetsListener(toolbar, (v, insets) -> {
+      Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+      v.setPadding(v.getPaddingLeft(), systemBars.top, v.getPaddingRight(), v.getPaddingBottom());
+      return insets;
+    });
+
+    // Handle top insets for main content - needs to account for status bar + toolbar
+    ViewCompat.setOnApplyWindowInsetsListener(mainScreen, (v, insets) -> {
+      Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+      ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+      // Get actionBarSize in pixels
+      int actionBarSize = 0;
+      android.util.TypedValue tv = new android.util.TypedValue();
+      if (getContext().getTheme().resolveAttribute(android.R.attr.actionBarSize, tv, true)) {
+        actionBarSize = android.util.TypedValue.complexToDimensionPixelSize(tv.data, getResources().getDisplayMetrics());
+      }
+      params.topMargin = systemBars.top + actionBarSize;
+      v.setLayoutParams(params);
+      return insets;
+    });
+
+    // Handle top insets for settings button
+    ViewCompat.setOnApplyWindowInsetsListener(settingsItem, (v, insets) -> {
+      Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+      ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+      int dpMargin = (int) (10 * getResources().getDisplayMetrics().density);
+      params.topMargin = systemBars.top + dpMargin;
+      v.setLayoutParams(params);
+      return insets;
+    });
+
+    // Handle top insets for feature tip rectangle
+    ViewCompat.setOnApplyWindowInsetsListener(featuretip_rectangle, (v, insets) -> {
+      Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+      ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+      int dpMargin = (int) (60 * getResources().getDisplayMetrics().density);
+      params.topMargin = systemBars.top + dpMargin;
+      v.setLayoutParams(params);
+      return insets;
+    });
+
+    // Handle bottom insets for submit button
+    ViewCompat.setOnApplyWindowInsetsListener(submitButton, (v, insets) -> {
+      Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+      ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+      params.bottomMargin = systemBars.bottom;
+      v.setLayoutParams(params);
+      return insets;
+    });
+
+    // Handle bottom insets for RecyclerView to ensure last row is visible
+    ViewCompat.setOnApplyWindowInsetsListener(recyclerView, (v, insets) -> {
+      Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+      v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(), systemBars.bottom);
+      return insets;
+    });
+    recyclerView.setClipToPadding(false);
   }
 }

--- a/app/src/main/java/com/aptoide/uploader/apps/view/MyStorePresenter.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/view/MyStorePresenter.java
@@ -183,6 +183,7 @@ public class MyStorePresenter implements Presenter {
   }
 
   private void handleSubmitAppEvent() {
+    // Step 1: On submit click, check connectivity and request notification permission
     compositeDisposable.add(view.getLifecycleEvent()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .flatMap(created -> view.submitAppEvent()
@@ -195,13 +196,32 @@ public class MyStorePresenter implements Presenter {
               }
             })
             .filter(hasConnection -> hasConnection)
-            .doOnNext(apps -> uploadPermissionProvider.requestExternalStoragePermission())
+            .doOnNext(__ -> uploadPermissionProvider.requestNotificationPermission())
             .retry())
         .subscribe(__ -> {
         }, throwable -> {
           throw new OnErrorNotImplementedException(throwable);
         }));
 
+    // Step 2: Handle notification permission result
+    compositeDisposable.add(view.getLifecycleEvent()
+        .filter(event -> event.equals(View.LifecycleEvent.CREATE))
+        .flatMap(__ -> uploadPermissionProvider.permissionResultNotification())
+        .observeOn(viewScheduler)
+        .doOnNext(granted -> {
+          if (granted) {
+            uploadPermissionProvider.requestExternalStoragePermission();
+          } else {
+            view.showNotificationPermissionRequired();
+          }
+        })
+        .retry()
+        .subscribe(__ -> {
+        }, throwable -> {
+          throw new OnErrorNotImplementedException(throwable);
+        }));
+
+    // Step 3: Handle storage permission result and start upload
     compositeDisposable.add(view.getLifecycleEvent()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .flatMap(__ -> uploadPermissionProvider.permissionResultExternalStorage())

--- a/app/src/main/java/com/aptoide/uploader/apps/view/MyStoreView.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/view/MyStoreView.java
@@ -29,6 +29,8 @@ public interface MyStoreView extends View {
 
   void showNoConnectivityError();
 
+  void showNotificationPermissionRequired();
+
   Observable<Object> submitAppEvent();
 
   Observable<SortingOrder> orderByEvent();

--- a/app/src/main/java/com/aptoide/uploader/apps/view/SettingsFragment.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/view/SettingsFragment.java
@@ -9,9 +9,14 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.ScrollView;
 import android.widget.TextView;
 import android.widget.Toast;
 import androidx.annotation.Nullable;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import com.aptoide.uploader.R;
 import com.aptoide.uploader.UploaderApplication;
 import com.aptoide.uploader.apps.InstalledApp;
@@ -45,6 +50,8 @@ public class SettingsFragment extends FragmentView implements SettingsView {
   private LinearLayout privacyPolicy;
   private RxAlertDialog logoutConfirmation;
   private List<ImageView> imageViewList;
+  private Toolbar toolbar;
+  private ScrollView scrollView;
 
   public SettingsFragment() {
   }
@@ -59,6 +66,8 @@ public class SettingsFragment extends FragmentView implements SettingsView {
 
   @Override public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
+    toolbar = view.findViewById(R.id.fragment_settings_toolbar);
+    scrollView = view.findViewById(R.id.fragment_settings_scrollview);
     backButton = view.findViewById(R.id.fragment_settings_back);
     profileAvatar = view.findViewById(R.id.fragment_settings_avatar);
     storeNameText = view.findViewById(R.id.fragment_settings_store_name);
@@ -73,6 +82,8 @@ public class SettingsFragment extends FragmentView implements SettingsView {
     termsConditions = view.findViewById(R.id.fragment_settings_terms);
     privacyPolicy = view.findViewById(R.id.fragment_settings_privacy);
 
+    setupEdgeToEdgeInsets(view);
+
     logoutConfirmation = new RxAlertDialog.Builder(
         new ContextThemeWrapper(getContext(), R.style.ConfirmationDialog)).setMessage(
         R.string.logout_confirmation_message)
@@ -84,7 +95,7 @@ public class SettingsFragment extends FragmentView implements SettingsView {
         ((UploaderApplication) getContext().getApplicationContext()).getAutoLoginManager(),
         ((UploaderApplication) getContext().getApplicationContext()).getAccountManager(),
         ((UploaderApplication) getContext().getApplicationContext()).getAppsManager(),
-        new SettingsNavigator(getFragmentManager(), getContext().getApplicationContext()),
+        new SettingsNavigator(getFragmentManager(), getContext()),
         ((UploaderApplication) getContext().getApplicationContext()).getInstalledAppsManager()).present();
   }
 
@@ -97,6 +108,8 @@ public class SettingsFragment extends FragmentView implements SettingsView {
     termsConditions = null;
     privacyPolicy = null;
     logoutConfirmation = null;
+    toolbar = null;
+    scrollView = null;
     GlideApp.get(getContext())
         .setMemoryCategory(MemoryCategory.NORMAL);
     super.onDestroyView();
@@ -211,5 +224,22 @@ public class SettingsFragment extends FragmentView implements SettingsView {
       imageViewList.get(i)
           .setVisibility(View.VISIBLE);
     }
+  }
+
+  private void setupEdgeToEdgeInsets(View view) {
+    // Handle top insets for toolbar (status bar)
+    ViewCompat.setOnApplyWindowInsetsListener(toolbar, (v, insets) -> {
+      Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+      v.setPadding(v.getPaddingLeft(), systemBars.top, v.getPaddingRight(), v.getPaddingBottom());
+      return insets;
+    });
+
+    // Handle bottom insets for scroll view content
+    ViewCompat.setOnApplyWindowInsetsListener(scrollView, (v, insets) -> {
+      Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+      v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(), systemBars.bottom);
+      return insets;
+    });
+    scrollView.setClipToPadding(false);
   }
 }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -2,62 +2,63 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white"
     >
+
+  <androidx.appcompat.widget.Toolbar
+      android:id="@+id/fragment_settings_toolbar"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:background="@color/light_blue_appbar"
+      android:minHeight="?attr/actionBarSize">
+
+    <LinearLayout
+        android:id="@+id/settings_appbar"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal"
+        >
+
+      <ImageView
+          android:id="@+id/fragment_settings_back"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center_vertical"
+          android:background="?attr/selectableItemBackgroundBorderless"
+          android:padding="8dp"
+          android:src="@drawable/ic_arrow_back_24dp"
+          />
+
+      <TextView
+          android:id="@+id/fragment_settings_title"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center_vertical"
+          android:paddingLeft="15dp"
+          android:paddingStart="15dp"
+          android:paddingRight="15dp"
+          android:paddingEnd="15dp"
+          android:textAppearance="@style/AppTheme.Toolbar.Title"
+          android:textColor="@color/white"
+          android:text="@string/action_settings"
+          />
+    </LinearLayout>
+  </androidx.appcompat.widget.Toolbar>
+
   <ScrollView
+      android:id="@+id/fragment_settings_scrollview"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
+      android:layout_below="@id/fragment_settings_toolbar"
       android:scrollbars="none"
       >
 
-  <LinearLayout
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="vertical"
-      >
-
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/fragment_settings_toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/light_blue_appbar"
-        android:minHeight="?attr/actionBarSize">
-
-      <LinearLayout
-          android:id="@+id/settings_appbar"
-          android:layout_width="match_parent"
-          android:layout_height="match_parent"
-          android:orientation="horizontal"
-          >
-
-        <ImageView
-            android:id="@+id/fragment_settings_back"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:background="@drawable/ic_arrow_back_24dp"
-            />
-
-        <TextView
-            android:id="@+id/fragment_settings_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingLeft="15dp"
-            android:paddingStart="15dp"
-            android:paddingRight="15dp"
-            android:paddingEnd="15dp"
-            android:textAppearance="@style/AppTheme.Toolbar.Title"
-            android:textColor="@color/white"
-            android:text="@string/action_settings"
-            />
-      </LinearLayout>
-    </androidx.appcompat.widget.Toolbar>
     <LinearLayout
         android:id="@+id/settings_body"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical"
         >
       <LinearLayout
@@ -324,6 +325,5 @@
             />
       </LinearLayout>
     </LinearLayout>
-  </LinearLayout>
   </ScrollView>
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
   <string name="logging_as">Logging in as</string>
   <string name="logging_in">Logging in</string>
   <string name="no_connectivity_error">Sorry, no internet connection available</string>
+  <string name="notification_permission_required">Please grant notification permission to track upload progress</string>
 
   <!-- Notifications -->
   <string name="application_notification_short_app_success_upload">App successfully uploaded</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -16,6 +16,9 @@
     <item name="colorPrimaryDark">#006294</item>
     <item name="android:windowBackground">@drawable/splash_screen</item>
     <item name="actionButtonStyle">@style/Widget.Aptoide.AppCompat.ActionButton</item>
+    <!-- Edge-to-edge support -->
+    <item name="android:statusBarColor">@android:color/transparent</item>
+    <item name="android:navigationBarColor">@android:color/transparent</item>
   </style>
 
   <style name="DialogTheme">

--- a/aptoide-authentication-core/build.gradle
+++ b/aptoide-authentication-core/build.gradle
@@ -2,36 +2,28 @@ apply plugin: 'java-library'
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
 
-buildscript {
-  repositories {
-    mavenCentral()
-  }
-  dependencies {
-    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71")
-  }
-}
-
-repositories {
-  mavenCentral()
+java {
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
 }
 
 dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
-  implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.71")
+  implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
 
   //local unit tests
-  testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.3.71")
-  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.7")
+  testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
+  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
   testImplementation("org.mockito:mockito-core:2.28.2")
 
 
   //converters
-  kapt("com.squareup.moshi:moshi-kotlin-codegen:1.9.3")
-  implementation("com.squareup.moshi:moshi-kotlin:1.9.3")
+  kapt("com.squareup.moshi:moshi-kotlin-codegen:1.15.0")
+  implementation("com.squareup.moshi:moshi-kotlin:1.15.0")
   implementation("com.squareup.retrofit2:converter-moshi:2.9.0")
 
   //network
   implementation("com.squareup.retrofit2:retrofit:2.9.0")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.7")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
 }

--- a/aptoide-authentication-rx/build.gradle
+++ b/aptoide-authentication-rx/build.gradle
@@ -1,20 +1,16 @@
 apply plugin: 'java-library'
 apply plugin: 'kotlin'
 
-buildscript {
-  repositories {
-    mavenCentral()
-  }
-  dependencies {
-    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71")
-  }
+java {
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
 }
 
 dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
   api project(path: ':aptoide-authentication-core')
 
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-rx2:1.3.7")
-  implementation("io.reactivex.rxjava2:rxjava:2.2.19")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-rx2:1.7.3")
+  implementation("io.reactivex.rxjava2:rxjava:2.2.21")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,12 @@
 buildscript {
-  ext.kotlin_version = '1.3.71'
+  ext.kotlin_version = '1.9.22'
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.6.3'
+    classpath 'com.android.tools.build:gradle:8.2.2'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-  }
-}
-
-allprojects {
-  repositories {
-    google()
-    jcenter()
   }
 }
 
@@ -26,4 +19,3 @@ ext {
   RAKAM_VERSION = '2.7.14'
   FACEBOOK_SDK_VERSION = '7.0.0'
 }
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ org.gradle.daemon=true
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.jvmargs=-Xmx8096M
-android.enableR8=true
+android.suppressUnsupportedCompileSdk=35
 
 STORE_FILE_BACKUP_UPLOADER=a
 STORE_PASSWORD_BACKUP_UPLOADER=a

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Apr 24 14:54:56 BST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,18 @@
-include ':app', ':aptoide-authentication-core',
-    ':aptoide-authentication-rx'
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "aptoide-uploader"
+include ':app', ':aptoide-authentication-core', ':aptoide-authentication-rx'


### PR DESCRIPTION
this depends on https://github.com/Aptoide/aptoide-uploader/pull/66


## Summary
  - Fix toolbar overlapping with device status bar on Auto-upload screen
  - Add proper WindowInsets handling following the pattern used in other screens (SettingsFragment, MyStoreFragment)
  - Handle bottom navigation bar insets for RecyclerView and submit button

  ## Changes
  - Added `setupEdgeToEdgeInsets()` method to `AutoUploadFragment`
  - Toolbar now applies top padding for status bar
  - RecyclerView applies bottom padding for navigation bar
  - Submit button applies bottom margin for navigation bar

  ## Jira
  [AND-629](https://aptoide.atlassian.net/browse/AND-629)

  ## Test plan
  - [ ] Test on device - navigation - into and out of the auto-upload screen
  - [ ] Verify toolbar is fully visible below status bar
  - [ ] Verify CONFIRM button doesn't overlap with navigation bar
  - [ ] Verify RecyclerView scrolls content properly with bottom insets

[AND-629]: https://aptoide.atlassian.net/browse/AND-629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ