### PR TITLE
Fix Room database schema crash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,15 @@ Required properties in `gradle.properties` or `local.properties`:
 - Database schema changes require migrations
 - Jira tickets use format: AND-XXXX
 
+### Room Database Change Checklist
+
+When modifying any `@Entity` class (adding/removing/renaming fields or changing types):
+
+1. **Add a migration** in `RoomMigrationProvider.kt` (e.g., `migration3to4`)
+2. **Bump the version** in `AppUploadsDatabase.java` to match
+3. **Register the migration** in `getAllMigrations()` so it's included in the migration array
+4. **Never use `OnErrorNotImplementedException`** in RxJava error handlers for database operations — use `Log.e` + `FirebaseCrashlytics.recordException()` instead
+
 ---
 
 ## TPO Configuration

--- a/app/src/main/java/com/aptoide/uploader/UploaderApplication.java
+++ b/app/src/main/java/com/aptoide/uploader/UploaderApplication.java
@@ -164,7 +164,8 @@ public class UploaderApplication extends Application {
     compositeDisposable.add(getInstallManager().insertAllInstalled()
         .subscribe(() -> {
         }, throwable -> {
-          throw new OnErrorNotImplementedException(throwable);
+          Log.e("UploaderApplication", "Error refreshing installed apps", throwable);
+          FirebaseCrashlytics.getInstance().recordException(throwable);
         }));
   }
 
@@ -172,7 +173,8 @@ public class UploaderApplication extends Application {
     compositeDisposable.add(getAutoUploadSelectsManager().insertAllInstalled()
         .subscribe(() -> {
         }, throwable -> {
-          throw new OnErrorNotImplementedException(throwable);
+          Log.e("UploaderApplication", "Error refreshing auto-upload selection", throwable);
+          FirebaseCrashlytics.getInstance().recordException(throwable);
         }));
   }
 

--- a/app/src/main/java/com/aptoide/uploader/apps/persistence/AppUploadsDatabase.java
+++ b/app/src/main/java/com/aptoide/uploader/apps/persistence/AppUploadsDatabase.java
@@ -12,7 +12,7 @@ import com.aptoide.uploader.apps.ObbTypeConverter;
 
 @Database(entities = {
     AppUploadStatus.class, InstalledApp.class, AutoUploadSelects.class
-}, version = 2) @TypeConverters({ ObbTypeConverter.class }) public abstract class AppUploadsDatabase
+}, version = 3) @TypeConverters({ ObbTypeConverter.class }) public abstract class AppUploadsDatabase
     extends RoomDatabase {
   private static volatile AppUploadsDatabase INSTANCE;
 
@@ -23,7 +23,8 @@ import com.aptoide.uploader.apps.ObbTypeConverter;
         if (INSTANCE == null) {
           INSTANCE = Room.databaseBuilder(context.getApplicationContext(), AppUploadsDatabase.class,
               "AppUploadsDatabase.db")
-              .addMigrations(roomMigrationProvider.getMigration())
+              .addMigrations(roomMigrationProvider.getAllMigrations())
+              .fallbackToDestructiveMigration()
               .build();
         }
       }

--- a/app/src/main/java/com/aptoide/uploader/apps/persistence/RoomMigrationProvider.kt
+++ b/app/src/main/java/com/aptoide/uploader/apps/persistence/RoomMigrationProvider.kt
@@ -20,4 +20,17 @@ class RoomMigrationProvider {
           "CREATE TABLE IF NOT EXISTS `AutoUploadSelects` (`packageName` TEXT NOT NULL, `isSelectedAutoUpload` INTEGER NOT NULL, PRIMARY KEY(`packageName`))")
     }
   }
+
+  val migration2to3 = object : Migration(2, 3) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+      database.execSQL(
+          "ALTER TABLE `Installed` ADD COLUMN `firstInstallTime` INTEGER NOT NULL DEFAULT 0")
+      database.execSQL(
+          "ALTER TABLE `Installed` ADD COLUMN `targetSdkVersion` INTEGER NOT NULL DEFAULT 0")
+      database.execSQL(
+          "ALTER TABLE `Installed` ADD COLUMN `minSdkVersion` INTEGER NOT NULL DEFAULT 0")
+    }
+  }
+
+  fun getAllMigrations(): Array<Migration> = arrayOf(migration, migration2to3)
 }


### PR DESCRIPTION
## Summary
Fixes a critical crash caused by a database schema mismatch between the app code and user devices. Users on older schema versions were crashing on startup when the app attempted database migrations.

## Changes
- **RoomMigrationProvider.kt**: Add migration v2→v3 that adds three new columns to the Installed table (firstInstallTime, targetSdkVersion, minSdkVersion) with proper ALTER TABLE statements
- **AppUploadsDatabase.java**: Bump database version from 2 to 3, register all migrations via getAllMigrations(), and add fallbackToDestructiveMigration() as a last-resort safety net
- **UploaderApplication.java**: Replace fatal OnErrorNotImplementedException throws with graceful error handling—errors are now logged via Log.e() and reported to Firebase Crashlytics instead of crashing the app

## Testing
The changes have been reviewed for correctness:
- Migration SQL is syntactically correct with proper NOT NULL DEFAULT 0 constraints
- Version bump (2→3) matches the new migration
- Error handling preserves diagnostics via Crashlytics while preventing crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)